### PR TITLE
Add generic support

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,1 @@
-export default (a: boolean, b: boolean): boolean => a && b;
+export default <T = boolean>(a: T, b: T): T => a && b;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,1 @@
-export default <T = boolean>(a: T, b: T): T => a && b;
+export default <T = boolean, P = T>(a: T, b: P): boolean => a && b;


### PR DESCRIPTION
This pull request adds TypeScript generics support to and. Specifically, it allows usage with two of the same type.

Considerations:
- Since this implementation only uses a single generic, `and(1, true)` and such is not possible
- In my opinion this is good for type safety but it may be a good topic of discussion to consider using two generics instead